### PR TITLE
Fix 'non-string literals in fail attribute'

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ Checks if all links mentioned in cargo docs of a crate are active
 $ cargo install cargo-doctor
 ```
 
-You will need nightly to run this crate as of 0.1.2. 
-
 (Please check cargo's documentation to learn how cargo install works and how to set up your system so it finds binaries installed by cargo.)
 
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -122,7 +122,7 @@ impl Handler {
 }
 
 #[derive(Debug, Fail)]
-#[fail(display = "broken links: {}", 0)]
+#[fail(display = "broken links: {}", _0)]
 pub struct BrokenLinks(pub LinksList);
 
 impl BrokenLinks {


### PR DESCRIPTION
https://boats.gitlab.io/failure/derive-fail.html#tuple-structs
Fixes #4 